### PR TITLE
feat: more extension setting types

### DIFF
--- a/app/src/main/java/dev/brahmkshatriya/echo/ui/settings/ExtensionFragment.kt
+++ b/app/src/main/java/dev/brahmkshatriya/echo/ui/settings/ExtensionFragment.kt
@@ -14,13 +14,17 @@ import dev.brahmkshatriya.echo.common.settings.Setting
 import dev.brahmkshatriya.echo.common.settings.SettingCategory
 import dev.brahmkshatriya.echo.common.settings.SettingItem
 import dev.brahmkshatriya.echo.common.settings.SettingList
+import dev.brahmkshatriya.echo.common.settings.SettingMultipleChoice
 import dev.brahmkshatriya.echo.common.settings.SettingSwitch
+import dev.brahmkshatriya.echo.common.settings.SettingTextInput
 import dev.brahmkshatriya.echo.plugger.ExtensionMetadata
 import dev.brahmkshatriya.echo.plugger.LyricsExtension
 import dev.brahmkshatriya.echo.plugger.MusicExtension
 import dev.brahmkshatriya.echo.plugger.TrackerExtension
 import dev.brahmkshatriya.echo.plugger.getExtension
 import dev.brahmkshatriya.echo.utils.MaterialListPreference
+import dev.brahmkshatriya.echo.utils.MaterialMultipleChoicePreference
+import dev.brahmkshatriya.echo.utils.MaterialTextInputPreference
 import dev.brahmkshatriya.echo.viewmodels.ExtensionViewModel
 
 class ExtensionFragment : BaseSettingsFragment() {
@@ -138,10 +142,40 @@ class ExtensionFragment : BaseSettingsFragment() {
                         it.key = this.key
                         defaultEntryIndex?.let { index ->
                             it.setDefaultValue(this.entryValues[index])
-                            it.summary = this.entryTitles[index]
                         }
                         it.entries = this.entryTitles.toTypedArray()
                         it.entryValues = this.entryValues.toTypedArray()
+
+                        it.isIconSpaceReserved = false
+                        it.layoutResource = R.layout.preference
+                        preferenceGroup.addPreference(it)
+                    }
+                }
+
+                is SettingMultipleChoice -> {
+                    MaterialMultipleChoicePreference(preferenceGroup.context).also {
+                        it.title = this.title
+                        it.key = this.key
+                        defaultEntryIndices?.let { indices ->
+                            it.setDefaultValue(indices.mapNotNull { index ->
+                                entryValues.getOrNull(index)
+                            }.toSet())
+                        }
+                        it.entries = this.entryTitles.toTypedArray()
+                        it.entryValues = this.entryValues.toTypedArray()
+
+                        it.isIconSpaceReserved = false
+                        it.layoutResource = R.layout.preference
+                        preferenceGroup.addPreference(it)
+                    }
+                }
+
+                is SettingTextInput -> {
+                    MaterialTextInputPreference(preferenceGroup.context).also {
+                        it.title = this.title
+                        it.key = this.key
+                        it.summary = this.summary
+                        it.text = this.defaultValue
 
                         it.isIconSpaceReserved = false
                         it.layoutResource = R.layout.preference

--- a/app/src/main/java/dev/brahmkshatriya/echo/utils/MaterialListPreference.kt
+++ b/app/src/main/java/dev/brahmkshatriya/echo/utils/MaterialListPreference.kt
@@ -6,14 +6,27 @@ import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import dev.brahmkshatriya.echo.R
 
 class MaterialListPreference(context: Context) : ListPreference(context) {
+
+    override fun onSetInitialValue(defaultValue: Any?) {
+        super.onSetInitialValue(defaultValue)
+        updateSummary()
+    }
+
     override fun onClick() {
         MaterialAlertDialogBuilder(context)
             .setSingleChoiceItems(entries, entryValues.indexOf(value)) { dialog, index ->
-                if (callChangeListener(entryValues[index].toString())) setValueIndex(index)
+                if (callChangeListener(entryValues[index].toString())) {
+                    setValueIndex(index)
+                    updateSummary()
+                }
                 dialog.dismiss()
             }
             .setNegativeButton(R.string.cancel) { dialog, _ -> dialog.dismiss() }.setTitle(title)
             .create()
             .show()
+    }
+
+    private fun updateSummary() {
+        summary = entry
     }
 }

--- a/app/src/main/java/dev/brahmkshatriya/echo/utils/MaterialMultipleChoicePreference.kt
+++ b/app/src/main/java/dev/brahmkshatriya/echo/utils/MaterialMultipleChoicePreference.kt
@@ -1,0 +1,48 @@
+package dev.brahmkshatriya.echo.utils
+
+import android.content.Context
+import androidx.preference.MultiSelectListPreference
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import dev.brahmkshatriya.echo.R
+
+class MaterialMultipleChoicePreference(context: Context) : MultiSelectListPreference(context) {
+
+    override fun onSetInitialValue(defaultValue: Any?) {
+        super.onSetInitialValue(defaultValue)
+        updateSummary()
+    }
+
+    override fun onClick() {
+        val selectedIndices = BooleanArray(entries.size) { index ->
+            values.contains(entryValues.getOrNull(index))
+        }
+
+        MaterialAlertDialogBuilder(context)
+            .setMultiChoiceItems(entries, selectedIndices) { _, which, isChecked ->
+                val value = entryValues.getOrNull(which)
+                if (isChecked && value != null) {
+                    values.add(value.toString())
+                } else {
+                    values.remove(value)
+                }
+            }
+            .setPositiveButton(R.string.ok) { dialog, _ ->
+                if (callChangeListener(values)) {
+                    setValues(values.toSet())
+                    updateSummary()
+                }
+                dialog.dismiss()
+            }
+            .setNegativeButton(R.string.cancel) { dialog, _ -> dialog.dismiss() }
+            .setTitle(title)
+            .create()
+            .show()
+    }
+
+    private fun updateSummary() {
+        summary = values.joinToString(", ") { value ->
+            val index = entryValues.indexOf(value)
+            if (index >= 0) entries.getOrNull(index).toString() else value
+        }
+    }
+}

--- a/app/src/main/java/dev/brahmkshatriya/echo/utils/MaterialTextInputPreference.kt
+++ b/app/src/main/java/dev/brahmkshatriya/echo/utils/MaterialTextInputPreference.kt
@@ -1,0 +1,40 @@
+package dev.brahmkshatriya.echo.utils
+
+import android.content.Context
+import android.widget.EditText
+import androidx.appcompat.app.AlertDialog
+import androidx.preference.EditTextPreference
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import dev.brahmkshatriya.echo.R
+
+class MaterialTextInputPreference(context: Context) : EditTextPreference(context) {
+
+    override fun onClick() {
+        val dialog = MaterialAlertDialogBuilder(context)
+            .setView(R.layout.dialog_edit_text)
+            .setPositiveButton(R.string.ok, null)
+            .setNegativeButton(R.string.cancel, null)
+            .setTitle(title)
+            .create()
+
+        dialog.setOnShowListener {
+            val editText = dialog.findViewById<EditText>(R.id.edit_text)
+            editText?.setText(text)
+            editText?.hint = summary
+
+            dialog.getButton(AlertDialog.BUTTON_POSITIVE).setOnClickListener {
+                val newText = editText?.text.toString()
+                if (callChangeListener(newText)) {
+                    text = newText
+                    dialog.dismiss()
+                }
+            }
+
+            dialog.getButton(AlertDialog.BUTTON_NEGATIVE).setOnClickListener {
+                dialog.dismiss()
+            }
+        }
+
+        dialog.show()
+    }
+}

--- a/app/src/main/res/layout/dialog_edit_text.xml
+++ b/app/src/main/res/layout/dialog_edit_text.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:padding="16dp">
+
+    <com.google.android.material.textfield.TextInputEditText
+        android:id="@+id/edit_text"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:importantForAutofill="no"
+        android:textSize="20sp"
+        android:hint="@string/settings"
+        android:inputType="text" />
+
+</LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -122,6 +122,7 @@
     <string name="playlist_name">Playlist Name</string>
     <string name="create">Create</string>
     <string name="cancel">Cancel</string>
+    <string name="ok">OK</string>
     <string name="playlist_name_empty">Playlist name cannot be empty</string>
     <string name="playlist_created">Playlist Created : %1$s</string>
     <string name="delete_playlist">Delete Playlist</string>

--- a/common/src/main/java/dev/brahmkshatriya/echo/common/settings/SettingMultipleChoice.kt
+++ b/common/src/main/java/dev/brahmkshatriya/echo/common/settings/SettingMultipleChoice.kt
@@ -1,0 +1,10 @@
+package dev.brahmkshatriya.echo.common.settings
+
+data class SettingMultipleChoice(
+    override val title: String,
+    override val key: String,
+    val summary: String? = null,
+    val entryTitles: List<String>,
+    val entryValues: List<String>,
+    val defaultEntryIndices: Set<Int>? = null
+) : Setting

--- a/common/src/main/java/dev/brahmkshatriya/echo/common/settings/SettingTextInput.kt
+++ b/common/src/main/java/dev/brahmkshatriya/echo/common/settings/SettingTextInput.kt
@@ -1,0 +1,8 @@
+package dev.brahmkshatriya.echo.common.settings
+
+data class SettingTextInput(
+    override val title: String,
+    override val key: String,
+    val summary: String? = null,
+    val defaultValue: String? = null
+) : Setting


### PR DESCRIPTION
This adds a multiple choice and a text input settings option for use in extensions. the ``SettingList`` also only showed the default options under the Title. I updated it to show the currently selected options.
<details>
  <summary>Multiple Choice</summary>

  ![Screenshot_20240714_163932_Echo](https://github.com/user-attachments/assets/49210ec7-316c-4260-890e-5bcf105e9690)

</details>

<details>
  <summary>Text Input</summary>

 ![Text Input](https://github.com/user-attachments/assets/b293469d-e4b2-4547-b101-14ddd659c7fb)

</details>
