### PR TITLE
fix: android 10 file perms

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -27,6 +27,7 @@
     <application
         android:name=".EchoApplication"
         android:allowBackup="true"
+        android:requestLegacyExternalStorage="true"
         android:appCategory="audio"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:usesCleartextTraffic="true"


### PR DESCRIPTION
Requests the app to use the legacy external storage model. It is not recommended to be used, since the changes in A11 and above break; however, since the app already correctly handles those changes, it's perfectly fine to use it here for A10 only.

Reference below:
> [Caution: After you update your app to target Android 11 (API level 30), the system ignores the requestLegacyExternalStorage attribute when your app is running on Android 11 devices, so your app must be ready to support scoped storage and to migrate app data for users on those devices.](https://developer.android.com/training/data-storage/use-cases#opt-out-in-production-app)


Users with the app already installed may need to disable and re-enable storage permissions for the permissions to update.

![image](https://github.com/user-attachments/assets/cf4589b0-a447-4559-b8e8-d9de1628a1d0)

Fixes #17