### PR TITLE
Feat: controller

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -9,7 +9,7 @@
 
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />
-
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.READ_MEDIA_AUDIO" />
     <uses-permission
         android:name="android.permission.READ_EXTERNAL_STORAGE"
@@ -93,6 +93,11 @@
                 <action android:name="android.media.browse.MediaBrowserService" />
             </intent-filter>
         </service>
+
+        <service
+            android:name=".extensions.ControllerExtensionService"
+            android:exported="false"
+            android:foregroundServiceType="mediaPlayback"/>
 
         <receiver
             android:name="androidx.media3.session.MediaButtonReceiver"

--- a/app/src/main/java/dev/brahmkshatriya/echo/PlayerService.kt
+++ b/app/src/main/java/dev/brahmkshatriya/echo/PlayerService.kt
@@ -4,6 +4,7 @@ import android.annotation.SuppressLint
 import android.app.PendingIntent
 import android.content.Intent
 import android.content.SharedPreferences
+import android.media.AudioManager
 import androidx.annotation.OptIn
 import androidx.media3.common.AudioAttributes
 import androidx.media3.common.C
@@ -153,7 +154,13 @@ class PlayerService : MediaLibraryService() {
             TrackingListener(exoPlayer, scope, extListFlow, trackerList, throwFlow)
         )
         exoPlayer.addListener(
-            ControllerListener(exoPlayer, scope, controllerList, throwFlow)
+            ControllerListener(
+                exoPlayer,
+                getSystemService(AUDIO_SERVICE) as AudioManager,
+                scope,
+                controllerList,
+                throwFlow
+            )
         )
         settings.registerOnSharedPreferenceChangeListener { prefs, key ->
             when (key) {

--- a/app/src/main/java/dev/brahmkshatriya/echo/PlayerService.kt
+++ b/app/src/main/java/dev/brahmkshatriya/echo/PlayerService.kt
@@ -23,6 +23,7 @@ import dev.brahmkshatriya.echo.playback.Current
 import dev.brahmkshatriya.echo.playback.PlayerCallback
 import dev.brahmkshatriya.echo.playback.ResumptionUtils
 import dev.brahmkshatriya.echo.playback.listeners.AudioFocusListener
+import dev.brahmkshatriya.echo.playback.listeners.ControllerListener
 import dev.brahmkshatriya.echo.playback.listeners.PlayerEventListener
 import dev.brahmkshatriya.echo.playback.listeners.Radio
 import dev.brahmkshatriya.echo.playback.listeners.TrackingListener
@@ -115,6 +116,7 @@ class PlayerService : MediaLibraryService() {
         val extListFlow = extensionLoader.extensions
         val extFlow = extensionLoader.current
         val trackerList = extensionLoader.trackers
+        val controllerList = extensionLoader.controllers
 
         val exoPlayer = createExoplayer(extListFlow)
         exoPlayer.prepare()
@@ -148,6 +150,9 @@ class PlayerService : MediaLibraryService() {
         )
         exoPlayer.addListener(
             TrackingListener(exoPlayer, scope, extListFlow, trackerList, throwFlow)
+        )
+        exoPlayer.addListener(
+            ControllerListener(exoPlayer, scope, controllerList, throwFlow)
         )
         settings.registerOnSharedPreferenceChangeListener { prefs, key ->
             when (key) {

--- a/app/src/main/java/dev/brahmkshatriya/echo/PlayerService.kt
+++ b/app/src/main/java/dev/brahmkshatriya/echo/PlayerService.kt
@@ -99,6 +99,7 @@ class PlayerService : MediaLibraryService() {
             .setWakeMode(C.WAKE_MODE_NETWORK)
             .setSkipSilenceEnabled(settings.getBoolean(SKIP_SILENCE, true))
             .setAudioAttributes(audioAttributes, true)
+            .setDeviceVolumeControlEnabled(true)
             .build()
             .also {
                 it.trackSelectionParameters = it.trackSelectionParameters

--- a/app/src/main/java/dev/brahmkshatriya/echo/PlayerService.kt
+++ b/app/src/main/java/dev/brahmkshatriya/echo/PlayerService.kt
@@ -2,9 +2,9 @@ package dev.brahmkshatriya.echo
 
 import android.annotation.SuppressLint
 import android.app.PendingIntent
+import android.app.Service
 import android.content.Intent
 import android.content.SharedPreferences
-import android.media.AudioManager
 import androidx.annotation.OptIn
 import androidx.media3.common.AudioAttributes
 import androidx.media3.common.C
@@ -156,7 +156,7 @@ class PlayerService : MediaLibraryService() {
         exoPlayer.addListener(
             ControllerListener(
                 exoPlayer,
-                getSystemService(AUDIO_SERVICE) as AudioManager,
+                this,
                 scope,
                 controllerList,
                 throwFlow

--- a/app/src/main/java/dev/brahmkshatriya/echo/di/ExtensionModule.kt
+++ b/app/src/main/java/dev/brahmkshatriya/echo/di/ExtensionModule.kt
@@ -14,6 +14,7 @@ import dev.brahmkshatriya.echo.common.ControllerExtension
 import dev.brahmkshatriya.echo.common.LyricsExtension
 import dev.brahmkshatriya.echo.common.MusicExtension
 import dev.brahmkshatriya.echo.common.TrackerExtension
+import dev.brahmkshatriya.echo.common.clients.CloseableClient
 import dev.brahmkshatriya.echo.db.models.UserEntity
 import dev.brahmkshatriya.echo.extensions.ExtensionLoader
 import dev.brahmkshatriya.echo.offline.OfflineExtension
@@ -58,6 +59,10 @@ class ExtensionModule {
 
     @Provides
     @Singleton
+    fun provideCloseableClientListFlow() = MutableStateFlow<List<CloseableClient>?>(null)
+
+    @Provides
+    @Singleton
     fun provideExtensionLoader(
         context: Application,
         throwableFlow: MutableSharedFlow<Throwable>,
@@ -72,6 +77,7 @@ class ExtensionModule {
         controllerListFlow: MutableStateFlow<List<ControllerExtension>?>,
         lyricsListFlow: MutableStateFlow<List<LyricsExtension>?>,
         extensionFlow: MutableStateFlow<MusicExtension?>,
+        closeableClientListFlow: MutableStateFlow<List<CloseableClient>?>,
     ) = run {
         val extensionDao = database.extensionDao()
         val userDao = database.userDao()
@@ -90,6 +96,7 @@ class ExtensionModule {
             controllerListFlow,
             lyricsListFlow,
             extensionFlow,
+            closeableClientListFlow
         )
     }
 }

--- a/app/src/main/java/dev/brahmkshatriya/echo/di/ExtensionModule.kt
+++ b/app/src/main/java/dev/brahmkshatriya/echo/di/ExtensionModule.kt
@@ -17,6 +17,7 @@ import dev.brahmkshatriya.echo.common.TrackerExtension
 import dev.brahmkshatriya.echo.db.models.UserEntity
 import dev.brahmkshatriya.echo.extensions.ExtensionLoader
 import dev.brahmkshatriya.echo.offline.OfflineExtension
+import dev.brahmkshatriya.echo.viewmodels.SnackBar
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import javax.inject.Singleton
@@ -60,6 +61,7 @@ class ExtensionModule {
     fun provideExtensionLoader(
         context: Application,
         throwableFlow: MutableSharedFlow<Throwable>,
+        mutableMessageFlow: MutableSharedFlow<SnackBar.Message>,
         database: EchoDatabase,
         settings: SharedPreferences,
         refresher: MutableSharedFlow<Boolean>,
@@ -77,6 +79,7 @@ class ExtensionModule {
             context,
             offlineExtension,
             throwableFlow,
+            mutableMessageFlow,
             extensionDao,
             userDao,
             settings,

--- a/app/src/main/java/dev/brahmkshatriya/echo/di/ExtensionModule.kt
+++ b/app/src/main/java/dev/brahmkshatriya/echo/di/ExtensionModule.kt
@@ -10,6 +10,7 @@ import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import dev.brahmkshatriya.echo.EchoDatabase
+import dev.brahmkshatriya.echo.common.ControllerExtension
 import dev.brahmkshatriya.echo.common.LyricsExtension
 import dev.brahmkshatriya.echo.common.MusicExtension
 import dev.brahmkshatriya.echo.common.TrackerExtension
@@ -52,6 +53,10 @@ class ExtensionModule {
 
     @Provides
     @Singleton
+    fun provideControllerListFlow() = MutableStateFlow<List<ControllerExtension>?>(null)
+
+    @Provides
+    @Singleton
     fun provideExtensionLoader(
         context: Application,
         throwableFlow: MutableSharedFlow<Throwable>,
@@ -62,6 +67,7 @@ class ExtensionModule {
         offlineExtension: OfflineExtension,
         extensionListFlow: MutableStateFlow<List<MusicExtension>?>,
         trackerListFlow: MutableStateFlow<List<TrackerExtension>?>,
+        controllerListFlow: MutableStateFlow<List<ControllerExtension>?>,
         lyricsListFlow: MutableStateFlow<List<LyricsExtension>?>,
         extensionFlow: MutableStateFlow<MusicExtension?>,
     ) = run {
@@ -78,6 +84,7 @@ class ExtensionModule {
             userFlow,
             extensionListFlow,
             trackerListFlow,
+            controllerListFlow,
             lyricsListFlow,
             extensionFlow,
         )

--- a/app/src/main/java/dev/brahmkshatriya/echo/extensions/ControllerExtensionService.kt
+++ b/app/src/main/java/dev/brahmkshatriya/echo/extensions/ControllerExtensionService.kt
@@ -12,6 +12,7 @@ import android.os.IBinder
 import androidx.core.app.NotificationCompat
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.common.Player
+import dev.brahmkshatriya.echo.common.clients.ControllerClient.RepeatMode
 
 @UnstableApi
 class ControllerExtensionService : Service() {
@@ -101,8 +102,8 @@ class ControllerExtensionService : Service() {
         player?.shuffleModeEnabled = enabled
     }
 
-    fun setRepeatMode(repeatMode: Int) {
-        player?.repeatMode = repeatMode
+    fun setRepeatMode(repeatMode: RepeatMode) {
+        player?.repeatMode = repeatMode.ordinal
     }
 
     override fun onDestroy() {

--- a/app/src/main/java/dev/brahmkshatriya/echo/extensions/ControllerExtensionService.kt
+++ b/app/src/main/java/dev/brahmkshatriya/echo/extensions/ControllerExtensionService.kt
@@ -107,6 +107,7 @@ class ControllerExtensionService : Service() {
     }
 
     override fun onDestroy() {
+        stopForeground(STOP_FOREGROUND_DETACH)
         player = null
         super.onDestroy()
     }

--- a/app/src/main/java/dev/brahmkshatriya/echo/extensions/ControllerExtensionService.kt
+++ b/app/src/main/java/dev/brahmkshatriya/echo/extensions/ControllerExtensionService.kt
@@ -1,0 +1,118 @@
+package dev.brahmkshatriya.echo.extensions
+
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.Service
+import android.content.Intent
+import dev.brahmkshatriya.echo.R
+import android.os.Binder
+import android.os.Build
+import android.os.IBinder
+import androidx.core.app.NotificationCompat
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.common.Player
+
+@UnstableApi
+class ControllerExtensionService : Service() {
+    private val binder = LocalBinder()
+    private var player: Player? = null
+
+    inner class LocalBinder : Binder() {
+        fun getService(): ControllerExtensionService = this@ControllerExtensionService
+    }
+
+    override fun onCreate() {
+        super.onCreate()
+        createNotificationChannel()
+    }
+
+    override fun onBind(intent: Intent): IBinder {
+        return binder
+    }
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        startForeground(NOTIFICATION_ID, createNotification())
+        return START_STICKY
+    }
+
+    private fun createNotificationChannel() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val channel = NotificationChannel(
+                NOTIFICATION_CHANNEL_ID,
+                getString(R.string.media_playback_controller),
+                NotificationManager.IMPORTANCE_LOW
+            ).apply {
+                description = getString(R.string.media_playback_controller_description)
+                setSound(null, null)
+            }
+            val notificationManager = getSystemService(NotificationManager::class.java)
+            notificationManager.createNotificationChannel(channel)
+        }
+    }
+
+    private fun createNotification(): Notification {
+        return NotificationCompat.Builder(this, NOTIFICATION_CHANNEL_ID)
+            .setContentTitle(getString(R.string.media_playback_controller))
+            .setContentText(getString(R.string.media_playback_controller_running))
+            .setSmallIcon(android.R.drawable.ic_media_play)
+            .setPriority(NotificationCompat.PRIORITY_LOW)
+            .setOngoing(true)
+            .build()
+    }
+
+    fun setPlayer(exoPlayer: Player) {
+        player = exoPlayer
+    }
+
+    fun play() {
+        player?.play()
+    }
+
+    fun pause() {
+        player?.pause()
+    }
+
+    fun seekToNext() {
+        player?.seekToNextMediaItem()
+    }
+
+    fun seekToPrevious() {
+        player?.seekToPreviousMediaItem()
+    }
+
+    fun seekTo(position: Long) {
+        player?.seekTo(position)
+    }
+
+    fun seekToMediaItem(index: Int) {
+        player?.seekTo(index, 0)
+    }
+
+    fun moveMediaItem(fromIndex: Int, toIndex: Int) {
+        player?.moveMediaItem(fromIndex, toIndex)
+    }
+
+    fun removeMediaItem(index: Int) {
+        player?.removeMediaItem(index)
+    }
+
+    fun setShuffleMode(enabled: Boolean) {
+        player?.shuffleModeEnabled = enabled
+    }
+
+    fun setRepeatMode(repeatMode: Int) {
+        player?.repeatMode = repeatMode
+    }
+
+    override fun onDestroy() {
+        player = null
+        super.onDestroy()
+    }
+
+    companion object {
+        private const val NOTIFICATION_ID = 1
+        private const val NOTIFICATION_CHANNEL_ID = "media_playback_channel"
+        const val ACTION_START_SERVICE = "action.START_SERVICE"
+    }
+}

--- a/app/src/main/java/dev/brahmkshatriya/echo/extensions/ControllerServiceHelper.kt
+++ b/app/src/main/java/dev/brahmkshatriya/echo/extensions/ControllerServiceHelper.kt
@@ -1,0 +1,73 @@
+package dev.brahmkshatriya.echo.extensions
+
+import android.app.Service
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import android.content.ServiceConnection
+import android.os.Build
+import android.os.IBinder
+import androidx.media3.common.Player
+import androidx.media3.common.util.UnstableApi
+
+
+@UnstableApi
+class ControllerServiceHelper(private val parentService: Service) {
+    private var mediaService: ControllerExtensionService? = null
+    private var isServiceBound = false
+    private var player: Player? = null
+
+    private val serviceConnection = object : ServiceConnection {
+        override fun onServiceConnected(name: ComponentName?, service: IBinder?) {
+            val binder = service as ControllerExtensionService.LocalBinder
+            mediaService = binder.getService()
+            isServiceBound = true
+            player?.let { mediaService?.setPlayer(it) }
+        }
+
+        override fun onServiceDisconnected(name: ComponentName?) {
+            mediaService = null
+            isServiceBound = false
+        }
+    }
+
+    fun startService(player: Player) {
+        this.player = player
+
+        val intent = Intent(parentService, ControllerExtensionService::class.java).apply {
+            action = ControllerExtensionService.ACTION_START_SERVICE
+        }
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            parentService.startForegroundService(intent)
+        } else {
+            parentService.startService(intent)
+        }
+
+        parentService.bindService(
+            Intent(parentService, ControllerExtensionService::class.java),
+            serviceConnection,
+            Context.BIND_AUTO_CREATE
+        )
+    }
+
+    fun stopService() {
+        if (isServiceBound) {
+            parentService.unbindService(serviceConnection)
+            isServiceBound = false
+        }
+        parentService.stopService(Intent(parentService, ControllerExtensionService::class.java))
+        player = null
+    }
+    fun play() = mediaService?.play()
+    fun pause() = mediaService?.pause()
+    fun seekToNext() = mediaService?.seekToNext()
+    fun seekToPrevious() = mediaService?.seekToPrevious()
+    fun seekTo(position: Long) = mediaService?.seekTo(position)
+    fun seekToMediaItem(index: Int) = mediaService?.seekToMediaItem(index)
+    fun moveMediaItem(fromIndex: Int, toIndex: Int) =
+        mediaService?.moveMediaItem(fromIndex, toIndex)
+    fun removeMediaItem(index: Int) = mediaService?.removeMediaItem(index)
+    fun setShuffleMode(enabled: Boolean) = mediaService?.setShuffleMode(enabled)
+    fun setRepeatMode(repeatMode: Int) = mediaService?.setRepeatMode(repeatMode)
+}

--- a/app/src/main/java/dev/brahmkshatriya/echo/extensions/ControllerServiceHelper.kt
+++ b/app/src/main/java/dev/brahmkshatriya/echo/extensions/ControllerServiceHelper.kt
@@ -9,6 +9,7 @@ import android.os.Build
 import android.os.IBinder
 import androidx.media3.common.Player
 import androidx.media3.common.util.UnstableApi
+import dev.brahmkshatriya.echo.common.clients.ControllerClient.RepeatMode
 
 
 @UnstableApi
@@ -69,5 +70,5 @@ class ControllerServiceHelper(private val parentService: Service) {
         mediaService?.moveMediaItem(fromIndex, toIndex)
     fun removeMediaItem(index: Int) = mediaService?.removeMediaItem(index)
     fun setShuffleMode(enabled: Boolean) = mediaService?.setShuffleMode(enabled)
-    fun setRepeatMode(repeatMode: Int) = mediaService?.setRepeatMode(repeatMode)
+    fun setRepeatMode(repeatMode: RepeatMode) = mediaService?.setRepeatMode(repeatMode)
 }

--- a/app/src/main/java/dev/brahmkshatriya/echo/extensions/ExtensionLoader.kt
+++ b/app/src/main/java/dev/brahmkshatriya/echo/extensions/ExtensionLoader.kt
@@ -323,8 +323,8 @@ class ExtensionLoader(
             scope: CoroutineScope,
             mutableMessageFlow: MutableSharedFlow<SnackBar.Message>
         ) {
-            client.postMessage = { message ->
-                scope.launch(Dispatchers.Main) {
+            client.setMessageHandler { message ->
+                scope.launch(Dispatchers.Main.immediate) {
                     mutableMessageFlow.emit(SnackBar.Message(message))
                 }
             }

--- a/app/src/main/java/dev/brahmkshatriya/echo/extensions/ExtensionRepo.kt
+++ b/app/src/main/java/dev/brahmkshatriya/echo/extensions/ExtensionRepo.kt
@@ -1,6 +1,7 @@
 package dev.brahmkshatriya.echo.extensions
 
 import android.content.Context
+import dev.brahmkshatriya.echo.common.clients.ControllerClient
 import dev.brahmkshatriya.echo.common.clients.ExtensionClient
 import dev.brahmkshatriya.echo.common.clients.LyricsClient
 import dev.brahmkshatriya.echo.common.clients.TrackerClient
@@ -87,6 +88,15 @@ class TrackerExtensionRepo(
     vararg repo: LazyPluginRepo<Metadata, TrackerClient>
 ) : ExtensionRepo<TrackerClient>(context, listener, fileChangeListener, *repo) {
     override val type = ExtensionType.TRACKER
+}
+
+class ControllerExtensionRepo(
+    context: Context,
+    listener: PackageChangeListener,
+    fileChangeListener: FileChangeListener,
+    vararg repo: LazyPluginRepo<Metadata, ControllerClient>
+) : ExtensionRepo<ControllerClient>(context, listener, fileChangeListener, *repo) {
+    override val type = ExtensionType.CONTROLLER
 }
 
 class LyricsExtensionRepo(

--- a/app/src/main/java/dev/brahmkshatriya/echo/playback/listeners/ControllerListener.kt
+++ b/app/src/main/java/dev/brahmkshatriya/echo/playback/listeners/ControllerListener.kt
@@ -1,0 +1,191 @@
+package dev.brahmkshatriya.echo.playback.listeners
+
+import androidx.media3.common.MediaItem
+import androidx.media3.common.Player
+import androidx.media3.common.Tracks
+import androidx.media3.common.util.UnstableApi
+import dev.brahmkshatriya.echo.common.ControllerExtension
+import dev.brahmkshatriya.echo.common.clients.ControllerClient
+import dev.brahmkshatriya.echo.extensions.get
+import dev.brahmkshatriya.echo.playback.MediaItemUtils.track
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.launch
+
+@UnstableApi
+class ControllerListener(
+    player: Player,
+    private val scope: CoroutineScope,
+    private val controllerExtensions: MutableStateFlow<List<ControllerExtension>?>,
+    private val throwableFlow: MutableSharedFlow<Throwable>
+) : PlayerListener(player) {
+
+    init {
+        scope.launch {
+            controllerExtensions.collect { extensions ->
+                extensions?.forEach {
+                    launch {
+                        registerController(it)
+                    }
+                }
+            }
+        }
+    }
+
+    private suspend fun registerController(extension: ControllerExtension) {
+        extension.get<ControllerClient, Unit>(throwableFlow) {
+            onPlayRequest = {
+                try {
+                    player.play()
+                } catch (e: Exception) {
+                    throwableFlow.emit(e)
+                }
+            }
+            onPauseRequest = {
+                try {
+                    player.pause()
+                } catch (e: Exception) {
+                    throwableFlow.emit(e)
+                }
+            }
+            onNextRequest = {
+                try {
+                    player.seekToNextMediaItem()
+                } catch (e: Exception) {
+                    throwableFlow.emit(e)
+                }
+            }
+            onPreviousRequest = {
+                try {
+                    player.seekToPreviousMediaItem()
+                } catch (e: Exception) {
+                    throwableFlow.emit(e)
+                }
+            }
+            onSeekRequest = { position ->
+                try {
+                    player.seekTo(position.toLong())
+                } catch (e: Exception) {
+                    throwableFlow.emit(e)
+                }
+            }
+            onMovePlaylistItemRequest = { fromIndex, toIndex ->
+                try {
+                    player.moveMediaItem(fromIndex, toIndex)
+                } catch (e: Exception) {
+                    throwableFlow.emit(e)
+                }
+            }
+            onRemovePlaylistItemRequest = { index ->
+                try {
+                    player.removeMediaItem(index)
+                } catch (e: Exception) {
+                    throwableFlow.emit(e)
+                }
+            }
+            onShuffleModeRequest = { enabled ->
+                try {
+                    player.shuffleModeEnabled = enabled
+                } catch (e: Exception) {
+                    throwableFlow.emit(e)
+                }
+            }
+            onRepeatModeRequest = { repeatMode ->
+                try {
+                    player.repeatMode = repeatMode
+                } catch (e: Exception) {
+                    throwableFlow.emit(e)
+                }
+            }
+            onVolumeRequest = { volume ->
+                try {
+                    player.volume = volume.toFloat()
+                } catch (e: Exception) {
+                    throwableFlow.emit(e)
+                }
+            }
+        }
+
+    }
+
+    private fun notifyControllers(block: suspend ControllerClient.() -> Unit) {
+        val controllers = controllerExtensions.value?.filter { it.metadata.enabled } ?: emptyList()
+        scope.launch {
+            controllers.forEach {
+                launch {
+                    it.get<ControllerClient, Unit>(throwableFlow) { block() }
+                }
+            }
+        }
+    }
+
+    override fun onTrackStart(mediaItem: MediaItem) {
+        val isPlaying = player.isPlaying
+        val position = player.currentPosition.toDouble()
+        val track = mediaItem.track
+
+        notifyControllers {
+            onPlaybackStateChanged(isPlaying, position, track)
+        }
+    }
+
+    override fun onTracksChanged(tracks: Tracks) {
+        super.onTracksChanged(tracks)
+        val playlist = List(player.mediaItemCount) { index ->
+            player.getMediaItemAt(index).track
+        }
+
+        notifyControllers {
+            onPlaylistChanged(playlist)
+        }
+    }
+
+    override fun onIsPlayingChanged(isPlaying: Boolean) {
+        super.onIsPlayingChanged(isPlaying)
+        val position = player.currentPosition.toDouble()
+        val track = player.currentMediaItem?.track ?: return
+
+        notifyControllers {
+            onPlaybackStateChanged(isPlaying, position, track)
+        }
+    }
+
+    override fun onShuffleModeEnabledChanged(shuffleModeEnabled: Boolean) {
+        super.onShuffleModeEnabledChanged(shuffleModeEnabled)
+        val repeatMode = player.repeatMode
+
+        notifyControllers {
+            onPlaybackModeChanged(shuffleModeEnabled, repeatMode)
+        }
+    }
+
+    override fun onRepeatModeChanged(repeatMode: Int) {
+        super.onRepeatModeChanged(repeatMode)
+        val shuffleModeEnabled = player.shuffleModeEnabled
+
+        notifyControllers {
+            onPlaybackModeChanged(shuffleModeEnabled, repeatMode)
+        }
+    }
+
+    override fun onPositionDiscontinuity(
+        oldPosition: Player.PositionInfo,
+        newPosition: Player.PositionInfo,
+        reason: Int
+    ) {
+        super.onPositionDiscontinuity(oldPosition, newPosition, reason)
+        val position = newPosition.positionMs.toDouble()
+
+        notifyControllers {
+            onPositionChanged(position)
+        }
+    }
+
+    override fun onVolumeChanged(volume: Float) {
+        super.onVolumeChanged(volume)
+        notifyControllers {
+            onVolumeChanged(player.volume.toDouble())
+        }
+    }
+}

--- a/app/src/main/java/dev/brahmkshatriya/echo/playback/listeners/ControllerListener.kt
+++ b/app/src/main/java/dev/brahmkshatriya/echo/playback/listeners/ControllerListener.kt
@@ -225,7 +225,7 @@ class ControllerListener(
     private fun getVolume(): Double {
         val maxVolume = audioManager.getStreamMaxVolume(AudioManager.STREAM_MUSIC)
         val volume = audioManager.getStreamVolume(AudioManager.STREAM_MUSIC)
-        return (volume.toDouble() / maxVolume.toDouble())
+        return volume.toDouble() / maxVolume.toDouble()
     }
 
 

--- a/app/src/main/java/dev/brahmkshatriya/echo/playback/listeners/ControllerListener.kt
+++ b/app/src/main/java/dev/brahmkshatriya/echo/playback/listeners/ControllerListener.kt
@@ -39,7 +39,7 @@ class ControllerListener(
     init {
         scope.launch {
             controllerExtensions.collect { extensions ->
-                extensions?.forEach {
+                extensions?.filter { it.metadata.enabled }?.forEach {
                     launch {
                         registerController(it)
                     }

--- a/app/src/main/java/dev/brahmkshatriya/echo/playback/listeners/ControllerListener.kt
+++ b/app/src/main/java/dev/brahmkshatriya/echo/playback/listeners/ControllerListener.kt
@@ -103,9 +103,9 @@ class ControllerListener(
             onSeekRequest = { position ->
                 tryOnMain(Player.COMMAND_SEEK_IN_CURRENT_MEDIA_ITEM) {
                     if (needsService.get()) {
-                        serviceHelper.seekTo(position.toLong())
+                        serviceHelper.seekTo(position)
                     } else {
-                        player.seekTo(position.toLong())
+                        player.seekTo(position)
                     }
                 }
             }
@@ -186,7 +186,7 @@ class ControllerListener(
     ): T? {
         return withContext(Dispatchers.Main.immediate) {
             try {
-                if (command == -1 || player.isCommandAvailable(command) == true) {
+                if (command == -1 || player.isCommandAvailable(command)) {
                     block()
                 } else {
                     null
@@ -255,10 +255,6 @@ class ControllerListener(
     override fun onTimelineChanged(timeline: Timeline, reason: Int) {
         super.onTimelineChanged(timeline, reason)
         updatePlaylist()
-    }
-
-    override fun onMediaItemTransition(mediaItem: MediaItem?, reason: Int) {
-        super.onMediaItemTransition(mediaItem, reason)
     }
 
     override fun onIsPlayingChanged(isPlaying: Boolean) {

--- a/app/src/main/java/dev/brahmkshatriya/echo/ui/extension/ExtensionInfoFragment.kt
+++ b/app/src/main/java/dev/brahmkshatriya/echo/ui/extension/ExtensionInfoFragment.kt
@@ -88,6 +88,7 @@ class ExtensionInfoFragment : Fragment() {
             ExtensionType.MUSIC -> viewModel.extensionListFlow.getExtension(clientId)
             ExtensionType.TRACKER -> viewModel.trackerListFlow.getExtension(clientId)
             ExtensionType.LYRICS -> viewModel.lyricsListFlow.getExtension(clientId)
+            ExtensionType.CONTROLLER -> viewModel.controllerListFlow.getExtension(clientId)
         }
 
         if (extension == null) {
@@ -127,6 +128,7 @@ class ExtensionInfoFragment : Fragment() {
             ExtensionType.MUSIC -> R.string.music
             ExtensionType.TRACKER -> R.string.tracker
             ExtensionType.LYRICS -> R.string.lyrics
+            ExtensionType.CONTROLLER -> R.string.controller
         }
         val typeString = getString(R.string.name_extension, getString(type))
         binding.extensionDescription.text = "$typeString\n\n${metadata.description}\n\n$byAuthor"

--- a/app/src/main/java/dev/brahmkshatriya/echo/ui/extension/ExtensionInstallerBottomSheet.kt
+++ b/app/src/main/java/dev/brahmkshatriya/echo/ui/extension/ExtensionInstallerBottomSheet.kt
@@ -94,6 +94,7 @@ class ExtensionInstallerBottomSheet : BottomSheetDialogFragment() {
             ExtensionType.MUSIC -> R.string.music
             ExtensionType.TRACKER -> R.string.tracker
             ExtensionType.LYRICS -> R.string.lyrics
+            ExtensionType.CONTROLLER -> R.string.controller
         }
         val typeString = getString(R.string.name_extension, getString(type))
         binding.extensionDescription.text = "$typeString\n\n${metadata.description}\n\n$byAuthor"

--- a/app/src/main/java/dev/brahmkshatriya/echo/ui/extension/ExtensionsListBottomSheet.kt
+++ b/app/src/main/java/dev/brahmkshatriya/echo/ui/extension/ExtensionsListBottomSheet.kt
@@ -55,6 +55,7 @@ class ExtensionsListBottomSheet : BottomSheetDialogFragment() {
             ExtensionType.LYRICS -> activityViewModels<LyricsViewModel>().value
             ExtensionType.MUSIC -> activityViewModels<ExtensionViewModel>().value
             ExtensionType.TRACKER -> throw IllegalStateException("Tracker not supported")
+            ExtensionType.CONTROLLER -> throw IllegalStateException("Controller not supported")
         }
 
         val listener = object : OnButtonCheckedListener {

--- a/app/src/main/java/dev/brahmkshatriya/echo/ui/login/LoginFragment.kt
+++ b/app/src/main/java/dev/brahmkshatriya/echo/ui/login/LoginFragment.kt
@@ -112,6 +112,7 @@ class LoginFragment : Fragment() {
             ExtensionType.MUSIC -> loginViewModel.extensionList.getExtension(clientId)
             ExtensionType.TRACKER -> loginViewModel.trackerList.getExtension(clientId)
             ExtensionType.LYRICS -> loginViewModel.lyricsList.getExtension(clientId)
+            ExtensionType.CONTROLLER -> loginViewModel.controllerList.getExtension(clientId)
         }
 
         if (extension == null) {

--- a/app/src/main/java/dev/brahmkshatriya/echo/ui/login/LoginViewModel.kt
+++ b/app/src/main/java/dev/brahmkshatriya/echo/ui/login/LoginViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dev.brahmkshatriya.echo.EchoDatabase
 import dev.brahmkshatriya.echo.R
+import dev.brahmkshatriya.echo.common.ControllerExtension
 import dev.brahmkshatriya.echo.common.Extension
 import dev.brahmkshatriya.echo.common.LyricsExtension
 import dev.brahmkshatriya.echo.common.MusicExtension
@@ -30,6 +31,7 @@ class LoginViewModel @Inject constructor(
     val extensionList: MutableStateFlow<List<MusicExtension>?>,
     val trackerList: MutableStateFlow<List<TrackerExtension>?>,
     val lyricsList: MutableStateFlow<List<LyricsExtension>?>,
+    val controllerList: MutableStateFlow<List<ControllerExtension>?>,
     private val context: Application,
     val messageFlow: MutableSharedFlow<SnackBar.Message>,
     database: EchoDatabase,

--- a/app/src/main/java/dev/brahmkshatriya/echo/ui/settings/ExtensionFragment.kt
+++ b/app/src/main/java/dev/brahmkshatriya/echo/ui/settings/ExtensionFragment.kt
@@ -92,6 +92,7 @@ class ExtensionFragment : BaseSettingsFragment() {
                     ExtensionType.MUSIC -> extensionListFlow.getExtension(extensionId)
                     ExtensionType.TRACKER -> trackerListFlow.getExtension(extensionId)
                     ExtensionType.LYRICS -> lyricsListFlow.getExtension(extensionId)
+                    ExtensionType.CONTROLLER -> controllerListFlow.getExtension(extensionId)
                 }
                 viewModelScope.launch {
                     client?.run(throwableFlow) {

--- a/app/src/main/java/dev/brahmkshatriya/echo/utils/prefs/MaterialTextInputPreference.kt
+++ b/app/src/main/java/dev/brahmkshatriya/echo/utils/prefs/MaterialTextInputPreference.kt
@@ -35,6 +35,7 @@ class MaterialTextInputPreference(context: Context) : EditTextPreference(context
                 val newText = editText?.text?.toString()
                 if (callChangeListener(newText)) {
                     text = newText
+                    updateSummary()
                     dialog.dismiss()
                 }
             }

--- a/app/src/main/java/dev/brahmkshatriya/echo/viewmodels/ExtensionViewModel.kt
+++ b/app/src/main/java/dev/brahmkshatriya/echo/viewmodels/ExtensionViewModel.kt
@@ -86,7 +86,7 @@ class ExtensionViewModel @Inject constructor(
     private val userDao = database.userDao()
     fun setExtension(extension: MusicExtension?) {
         setupMusicExtension(
-            viewModelScope, settings, extensionFlow, userDao, userFlow, throwableFlow, extension
+            viewModelScope, settings, extensionFlow, userDao, userFlow, throwableFlow, messageFlow, extension
         )
     }
 

--- a/app/src/main/java/dev/brahmkshatriya/echo/viewmodels/ExtensionViewModel.kt
+++ b/app/src/main/java/dev/brahmkshatriya/echo/viewmodels/ExtensionViewModel.kt
@@ -14,6 +14,7 @@ import dev.brahmkshatriya.echo.EchoDatabase
 import dev.brahmkshatriya.echo.ExtensionOpenerActivity
 import dev.brahmkshatriya.echo.ExtensionOpenerActivity.Companion.installExtension
 import dev.brahmkshatriya.echo.R
+import dev.brahmkshatriya.echo.common.ControllerExtension
 import dev.brahmkshatriya.echo.common.Extension
 import dev.brahmkshatriya.echo.common.LyricsExtension
 import dev.brahmkshatriya.echo.common.MusicExtension
@@ -62,6 +63,7 @@ class ExtensionViewModel @Inject constructor(
     val extensionListFlow: MutableStateFlow<List<MusicExtension>?>,
     val trackerListFlow: MutableStateFlow<List<TrackerExtension>?>,
     val lyricsListFlow: MutableStateFlow<List<LyricsExtension>?>,
+    val controllerListFlow: MutableStateFlow<List<ControllerExtension>?>,
     val extensionFlow: MutableStateFlow<MusicExtension?>,
     val settings: SharedPreferences,
     val database: EchoDatabase,
@@ -130,6 +132,7 @@ class ExtensionViewModel @Inject constructor(
         ExtensionType.MUSIC -> extensionListFlow
         ExtensionType.TRACKER -> trackerListFlow
         ExtensionType.LYRICS -> lyricsListFlow
+        ExtensionType.CONTROLLER -> controllerListFlow
     }
 
     fun moveExtensionItem(type: ExtensionType, toPos: Int, fromPos: Int) {

--- a/app/src/main/java/dev/brahmkshatriya/echo/viewmodels/ExtensionViewModel.kt
+++ b/app/src/main/java/dev/brahmkshatriya/echo/viewmodels/ExtensionViewModel.kt
@@ -19,6 +19,7 @@ import dev.brahmkshatriya.echo.common.Extension
 import dev.brahmkshatriya.echo.common.LyricsExtension
 import dev.brahmkshatriya.echo.common.MusicExtension
 import dev.brahmkshatriya.echo.common.TrackerExtension
+import dev.brahmkshatriya.echo.common.clients.CloseableClient
 import dev.brahmkshatriya.echo.common.clients.SettingsChangeListenerClient
 import dev.brahmkshatriya.echo.common.helpers.ExtensionType
 import dev.brahmkshatriya.echo.common.helpers.ImportType
@@ -64,6 +65,7 @@ class ExtensionViewModel @Inject constructor(
     val trackerListFlow: MutableStateFlow<List<TrackerExtension>?>,
     val lyricsListFlow: MutableStateFlow<List<LyricsExtension>?>,
     val controllerListFlow: MutableStateFlow<List<ControllerExtension>?>,
+    private val closeableFlow: MutableStateFlow<List<CloseableClient>?>,
     val extensionFlow: MutableStateFlow<MusicExtension?>,
     val settings: SharedPreferences,
     val database: EchoDatabase,
@@ -86,7 +88,7 @@ class ExtensionViewModel @Inject constructor(
     private val userDao = database.userDao()
     fun setExtension(extension: MusicExtension?) {
         setupMusicExtension(
-            viewModelScope, settings, extensionFlow, userDao, userFlow, throwableFlow, messageFlow, extension
+            viewModelScope, settings, extensionFlow, userDao, userFlow, throwableFlow, messageFlow, closeableFlow, extension
         )
     }
 

--- a/app/src/main/res/layout/fragment_manage_extensions.xml
+++ b/app/src/main/res/layout/fragment_manage_extensions.xml
@@ -44,6 +44,11 @@
                 android:layout_height="wrap_content"
                 android:text="@string/lyrics" />
 
+            <com.google.android.material.tabs.TabItem
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/controller" />
+
         </com.google.android.material.tabs.TabLayout>
 
     </com.google.android.material.appbar.AppBarLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -268,6 +268,9 @@
     <string name="backgrounds">Backgrounds</string>
     <string name="source_selection">Source Selection</string>
     <string name="controller">Controller</string>
+    <string name="media_playback_controller">Media Playback Controller</string>
+    <string name="media_playback_controller_description">Control media playback from controller extensions</string>
+    <string name="media_playback_controller_running">Media playback controller is running</string>
     <string-array name="stream_qualities">
         <item>Highest</item>
         <item>Medium</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -267,6 +267,7 @@
     <string name="sources">Sources</string>
     <string name="backgrounds">Backgrounds</string>
     <string name="source_selection">Source Selection</string>
+    <string name="controller">Controller</string>
     <string-array name="stream_qualities">
         <item>Highest</item>
         <item>Medium</item>

--- a/common/src/main/java/dev/brahmkshatriya/echo/common/Extension.kt
+++ b/common/src/main/java/dev/brahmkshatriya/echo/common/Extension.kt
@@ -1,5 +1,6 @@
 package dev.brahmkshatriya.echo.common
 
+import dev.brahmkshatriya.echo.common.clients.ControllerClient
 import dev.brahmkshatriya.echo.common.clients.ExtensionClient
 import dev.brahmkshatriya.echo.common.clients.LyricsClient
 import dev.brahmkshatriya.echo.common.clients.TrackerClient
@@ -30,3 +31,8 @@ data class LyricsExtension(
     override val metadata: Metadata,
     override val instance: Lazy<Result<LyricsClient>>,
 ) : Extension<LyricsClient>(ExtensionType.LYRICS, metadata, instance)
+
+data class ControllerExtension(
+    override val metadata: Metadata,
+    override val instance: Lazy<Result<ControllerClient>>,
+) : Extension<ControllerClient>(ExtensionType.CONTROLLER, metadata, instance)

--- a/common/src/main/java/dev/brahmkshatriya/echo/common/clients/CloseableClient.kt
+++ b/common/src/main/java/dev/brahmkshatriya/echo/common/clients/CloseableClient.kt
@@ -1,5 +1,9 @@
 package dev.brahmkshatriya.echo.common.clients
 
 interface CloseableClient {
+    /**
+     * Called when the app and player are closed.
+     * Useful for cleaning up resources.
+     */
     fun close()
 }

--- a/common/src/main/java/dev/brahmkshatriya/echo/common/clients/CloseableClient.kt
+++ b/common/src/main/java/dev/brahmkshatriya/echo/common/clients/CloseableClient.kt
@@ -1,0 +1,5 @@
+package dev.brahmkshatriya.echo.common.clients
+
+interface CloseableClient {
+    fun close()
+}

--- a/common/src/main/java/dev/brahmkshatriya/echo/common/clients/ControllerClient.kt
+++ b/common/src/main/java/dev/brahmkshatriya/echo/common/clients/ControllerClient.kt
@@ -3,7 +3,7 @@ package dev.brahmkshatriya.echo.common.clients
 import dev.brahmkshatriya.echo.common.models.Track
 import kotlinx.serialization.Serializable
 
-interface ControllerClient : ExtensionClient {
+abstract class ControllerClient : ExtensionClient {
     @Serializable
     enum class RepeatMode {
         OFF,
@@ -39,7 +39,7 @@ interface ControllerClient : ExtensionClient {
      * Whether the the extension can perform actions when the player is paused.
      * Only set this to false if you are sure that the extension does not need to perform any actions when the player is paused.
      */
-    var runsDuringPause: Boolean
+    abstract var runsDuringPause: Boolean
 
     // app -> controller
     /**
@@ -48,14 +48,14 @@ interface ControllerClient : ExtensionClient {
      * @param position The current position of the track.
      * @param track The current track in the player.
      */
-    suspend fun onPlaybackStateChanged(isPlaying: Boolean, position: Long, track: Track?)
+    abstract suspend fun onPlaybackStateChanged(isPlaying: Boolean, position: Long, track: Track?)
 
     /**
      * Called when the playlist changes.
      * @param playlist The new playlist.
      * The first track is not necessarily the current track.
      */
-    suspend fun onPlaylistChanged(playlist: List<Track>)
+    abstract suspend fun onPlaylistChanged(playlist: List<Track>)
 
     /**
      * Called when the playback mode changes.
@@ -63,87 +63,87 @@ interface ControllerClient : ExtensionClient {
      * @param repeatMode The repeat mode.
      * @see RepeatMode
      */
-    suspend fun onPlaybackModeChanged(isShuffle: Boolean, repeatMode: RepeatMode)
+    abstract suspend fun onPlaybackModeChanged(isShuffle: Boolean, repeatMode: RepeatMode)
 
     /**
      * Called when the position of the track changes.
      * @param position The new position of the track.
      */
-    suspend fun onPositionChanged(position: Long)
+    abstract suspend fun onPositionChanged(position: Long)
 
     /**
      * Called when the volume of the player changes.
      * @param volume The new volume of the player.
      */
-    suspend fun onVolumeChanged(volume: Double)
+    abstract suspend fun onVolumeChanged(volume: Double)
 
     // controller -> app
     /**
      * Called when the controller requests the current state of the player.
      * @return The current state of the player.
      */
-    var onRequestState: (suspend () -> PlayerState)?
+    var onRequestState: (suspend () -> PlayerState)? = null
 
     /**
      * Called when the controller requests to play the player.
      */
-    var onPlayRequest: (suspend () -> Unit)?
+    var onPlayRequest: (suspend () -> Unit)? = null
 
     /**
      * Called when the controller requests to pause the player.
      */
-    var onPauseRequest: (suspend () -> Unit)?
+    var onPauseRequest: (suspend () -> Unit)? = null
 
     /**
      * Called when the controller requests to play the next track.
      */
-    var onNextRequest: (suspend () -> Unit)?
+    var onNextRequest: (suspend () -> Unit)? = null
 
     /**
      * Called when the controller requests to play the previous track.
      */
-    var onPreviousRequest: (suspend () -> Unit)?
+    var onPreviousRequest: (suspend () -> Unit)? = null
 
     /**
      * Called when the controller requests to seek to a position in the track.
      * passes the position in milliseconds.
      */
-    var onSeekRequest: (suspend (position: Long) -> Unit)?
+    var onSeekRequest: (suspend (position: Long) -> Unit)? = null
 
     /**
      * Called when the controller requests to seek to a track in the playlist.
      * passes the index of the track.
      */
-    var onSeekToMediaItemRequest: (suspend (index: Int) -> Unit)?
+    var onSeekToMediaItemRequest: (suspend (index: Int) -> Unit)? = null
 
     /**
      * Called when the controller requests to move a track in the playlist.
      * passes the index of the track to move and the new index.
      */
-    var onMovePlaylistItemRequest: (suspend (fromIndex: Int, toIndex: Int) -> Unit)?
+    var onMovePlaylistItemRequest: (suspend (fromIndex: Int, toIndex: Int) -> Unit)? = null
 
     /**
      * Called when the controller requests to remove a track from the playlist.
      * passes the index of the track to remove.
      */
-    var onRemovePlaylistItemRequest: (suspend (index: Int) -> Unit)?
+    var onRemovePlaylistItemRequest: (suspend (index: Int) -> Unit)? = null
 
     /**
      * Called when the controller requests to enable or disable shuffle mode.
      * passes whether shuffle mode should be enabled.
      */
-    var onShuffleModeRequest: (suspend (enabled: Boolean) -> Unit)?
+    var onShuffleModeRequest: (suspend (enabled: Boolean) -> Unit)? = null
 
     /**
      * Called when the controller requests to change the repeat mode.
      * passes the new repeat mode.
      * @see RepeatMode
      */
-    var onRepeatModeRequest: (suspend (repeatMode: RepeatMode) -> Unit)?
+    var onRepeatModeRequest: (suspend (repeatMode: RepeatMode) -> Unit)? = null
 
     /**
      * Called when the controller requests to change the volume of the player.
      * passes the new volume of the player.
      */
-    var onVolumeRequest: (suspend (volume: Double) -> Unit)?
+    var onVolumeRequest: (suspend (volume: Double) -> Unit)? = null
 }

--- a/common/src/main/java/dev/brahmkshatriya/echo/common/clients/ControllerClient.kt
+++ b/common/src/main/java/dev/brahmkshatriya/echo/common/clients/ControllerClient.kt
@@ -1,0 +1,24 @@
+package dev.brahmkshatriya.echo.common.clients
+
+import dev.brahmkshatriya.echo.common.models.Track
+
+interface ControllerClient : ExtensionClient {
+    // app -> controller
+    suspend fun onPlaybackStateChanged(isPlaying: Boolean, position: Double, track: Track)
+    suspend fun onPlaylistChanged(playlist: List<Track>)
+    suspend fun onPlaybackModeChanged(isShuffle: Boolean, repeatState: Int)
+    suspend fun onPositionChanged(position: Double)
+    suspend fun onVolumeChanged(volume: Double)
+
+    // controller -> app
+    var onPlayRequest: (suspend () -> Unit)?
+    var onPauseRequest: (suspend () -> Unit)?
+    var onNextRequest: (suspend () -> Unit)?
+    var onPreviousRequest: (suspend () -> Unit)?
+    var onSeekRequest: (suspend (position: Double) -> Unit)?
+    var onMovePlaylistItemRequest: (suspend (fromIndex: Int, toIndex: Int) -> Unit)?
+    var onRemovePlaylistItemRequest: (suspend (index: Int) -> Unit)?
+    var onShuffleModeRequest: (suspend (enabled: Boolean) -> Unit)?
+    var onRepeatModeRequest: (suspend (repeatMode: Int) -> Unit)?
+    var onVolumeRequest: (suspend (volume: Double) -> Unit)?
+}

--- a/common/src/main/java/dev/brahmkshatriya/echo/common/clients/ControllerClient.kt
+++ b/common/src/main/java/dev/brahmkshatriya/echo/common/clients/ControllerClient.kt
@@ -3,22 +3,96 @@ package dev.brahmkshatriya.echo.common.clients
 import dev.brahmkshatriya.echo.common.models.Track
 
 interface ControllerClient : ExtensionClient {
+    /**
+     * Whether the the extension can perform actions when the player is paused.
+     * Only set this to false if you are sure that the extension does not need to perform any actions when the player is paused.
+     */
+    var runsDuringPause: Boolean
+
     // app -> controller
+    /**
+     * Called when the playback state changes.
+     * @param isPlaying Whether the player is playing.
+     * @param position The current position of the track.
+     * @param track The current track in the player.
+     */
     suspend fun onPlaybackStateChanged(isPlaying: Boolean, position: Double, track: Track)
+    /**
+     * Called when the playlist changes.
+     * @param playlist The new playlist.
+     * The first track is not necessarily the current track.
+     */
     suspend fun onPlaylistChanged(playlist: List<Track>)
+    /**
+     * Called when the playback mode changes.
+     * @param isShuffle Whether shuffle mode is enabled.
+     * @param repeatState The repeat mode.
+     * @see androidx.media3.common.Player.REPEAT_MODE_OFF
+     */
     suspend fun onPlaybackModeChanged(isShuffle: Boolean, repeatState: Int)
+    /**
+     * Called when the position of the track changes.
+     * @param position The new position of the track.
+     */
     suspend fun onPositionChanged(position: Double)
+    /**
+     * Called when the volume of the player changes.
+     * @param volume The new volume of the player.
+     */
     suspend fun onVolumeChanged(volume: Double)
 
     // controller -> app
+    /**
+     * Called when the controller requests to play the player.
+     */
     var onPlayRequest: (suspend () -> Unit)?
+    /**
+     * Called when the controller requests to pause the player.
+     */
     var onPauseRequest: (suspend () -> Unit)?
+    /**
+     * Called when the controller requests to play the next track.
+     */
     var onNextRequest: (suspend () -> Unit)?
+    /**
+     * Called when the controller requests to play the previous track.
+     */
     var onPreviousRequest: (suspend () -> Unit)?
+    /**
+     * Called when the controller requests to seek to a position in the track.
+     * @param position The position to seek to.
+     */
     var onSeekRequest: (suspend (position: Double) -> Unit)?
+    /**
+     * Called when the controller requests to seek to a track in the playlist.
+     * @param index The index of the track to seek to.
+     */
+    var onSeekToMediaItemRequest: (suspend (index: Int) -> Unit)?
+    /**
+     * Called when the controller requests to move a track in the playlist.
+     * @param fromIndex The index of the track to move.
+     * @param toIndex The index to move the track to.
+     */
     var onMovePlaylistItemRequest: (suspend (fromIndex: Int, toIndex: Int) -> Unit)?
+    /**
+     * Called when the controller requests to remove a track from the playlist.
+     * @param index The index of the track to remove.
+     */
     var onRemovePlaylistItemRequest: (suspend (index: Int) -> Unit)?
+    /**
+     * Called when the controller requests to enable or disable shuffle mode.
+     * @param enabled Whether shuffle mode should be enabled.
+     */
     var onShuffleModeRequest: (suspend (enabled: Boolean) -> Unit)?
+    /**
+     * Called when the controller requests to change the repeat mode.
+     * @param repeatMode The new repeat mode.
+     * @see androidx.media3.common.Player.REPEAT_MODE_OFF
+     */
     var onRepeatModeRequest: (suspend (repeatMode: Int) -> Unit)?
+    /**
+     * Called when the controller requests to change the volume of the player.
+     * @param volume The new volume of the player.
+     */
     var onVolumeRequest: (suspend (volume: Double) -> Unit)?
 }

--- a/common/src/main/java/dev/brahmkshatriya/echo/common/clients/ControllerClient.kt
+++ b/common/src/main/java/dev/brahmkshatriya/echo/common/clients/ControllerClient.kt
@@ -1,8 +1,40 @@
 package dev.brahmkshatriya.echo.common.clients
 
 import dev.brahmkshatriya.echo.common.models.Track
+import kotlinx.serialization.Serializable
 
 interface ControllerClient : ExtensionClient {
+    @Serializable
+    enum class RepeatMode {
+        OFF,
+        ONE,
+        ALL
+    }
+
+    /**
+     * The current state of the player.
+     * @param isPlaying Whether the player is playing.
+     * @param currentTrack The current track in the player.
+     * @param currentPosition The current position of the track.
+     * @param playlist The current playlist.
+     * @param currentIndex The index of the current track in the playlist. -1 if the playlist is empty.
+     * @param shuffle Whether shuffle mode is enabled.
+     * @param repeatMode The repeat mode.
+     * @see RepeatMode
+     * @param volume The volume of the player normalized between 0 and 1.
+     */
+    @Serializable
+    data class PlayerState(
+        val isPlaying: Boolean = false,
+        val currentTrack: Track? = null,
+        val currentPosition: Long = 0,
+        val playlist: List<Track> = emptyList(),
+        val currentIndex: Int = 0,
+        val shuffle: Boolean = false,
+        val repeatMode: RepeatMode = RepeatMode.OFF,
+        val volume: Double = 0.0
+    )
+
     /**
      * Whether the the extension can perform actions when the player is paused.
      * Only set this to false if you are sure that the extension does not need to perform any actions when the player is paused.
@@ -16,25 +48,29 @@ interface ControllerClient : ExtensionClient {
      * @param position The current position of the track.
      * @param track The current track in the player.
      */
-    suspend fun onPlaybackStateChanged(isPlaying: Boolean, position: Double, track: Track)
+    suspend fun onPlaybackStateChanged(isPlaying: Boolean, position: Long, track: Track?)
+
     /**
      * Called when the playlist changes.
      * @param playlist The new playlist.
      * The first track is not necessarily the current track.
      */
     suspend fun onPlaylistChanged(playlist: List<Track>)
+
     /**
      * Called when the playback mode changes.
      * @param isShuffle Whether shuffle mode is enabled.
-     * @param repeatState The repeat mode.
-     * @see androidx.media3.common.Player.REPEAT_MODE_OFF
+     * @param repeatMode The repeat mode.
+     * @see RepeatMode
      */
-    suspend fun onPlaybackModeChanged(isShuffle: Boolean, repeatState: Int)
+    suspend fun onPlaybackModeChanged(isShuffle: Boolean, repeatMode: RepeatMode)
+
     /**
      * Called when the position of the track changes.
      * @param position The new position of the track.
      */
-    suspend fun onPositionChanged(position: Double)
+    suspend fun onPositionChanged(position: Long)
+
     /**
      * Called when the volume of the player changes.
      * @param volume The new volume of the player.
@@ -43,56 +79,71 @@ interface ControllerClient : ExtensionClient {
 
     // controller -> app
     /**
+     * Called when the controller requests the current state of the player.
+     * @return The current state of the player.
+     */
+    var onRequestState: (suspend () -> PlayerState)?
+
+    /**
      * Called when the controller requests to play the player.
      */
     var onPlayRequest: (suspend () -> Unit)?
+
     /**
      * Called when the controller requests to pause the player.
      */
     var onPauseRequest: (suspend () -> Unit)?
+
     /**
      * Called when the controller requests to play the next track.
      */
     var onNextRequest: (suspend () -> Unit)?
+
     /**
      * Called when the controller requests to play the previous track.
      */
     var onPreviousRequest: (suspend () -> Unit)?
+
     /**
      * Called when the controller requests to seek to a position in the track.
-     * @param position The position to seek to.
+     * passes the position in milliseconds.
      */
-    var onSeekRequest: (suspend (position: Double) -> Unit)?
+    var onSeekRequest: (suspend (position: Long) -> Unit)?
+
     /**
      * Called when the controller requests to seek to a track in the playlist.
-     * @param index The index of the track to seek to.
+     * passes the index of the track.
      */
     var onSeekToMediaItemRequest: (suspend (index: Int) -> Unit)?
+
     /**
      * Called when the controller requests to move a track in the playlist.
-     * @param fromIndex The index of the track to move.
-     * @param toIndex The index to move the track to.
+     * passes the index of the track to move and the new index.
      */
     var onMovePlaylistItemRequest: (suspend (fromIndex: Int, toIndex: Int) -> Unit)?
+
     /**
      * Called when the controller requests to remove a track from the playlist.
-     * @param index The index of the track to remove.
+     * passes the index of the track to remove.
      */
     var onRemovePlaylistItemRequest: (suspend (index: Int) -> Unit)?
+
     /**
      * Called when the controller requests to enable or disable shuffle mode.
-     * @param enabled Whether shuffle mode should be enabled.
+     * passes whether shuffle mode should be enabled.
      */
     var onShuffleModeRequest: (suspend (enabled: Boolean) -> Unit)?
+
     /**
      * Called when the controller requests to change the repeat mode.
-     * @param repeatMode The new repeat mode.
-     * @see androidx.media3.common.Player.REPEAT_MODE_OFF
+     * passes the new repeat mode.
+     * @see RepeatMode
      */
-    var onRepeatModeRequest: (suspend (repeatMode: Int) -> Unit)?
+    var onRepeatModeRequest: (suspend (repeatMode: RepeatMode) -> Unit)?
+
     /**
      * Called when the controller requests to change the volume of the player.
-     * @param volume The new volume of the player.
+     * passes the new volume of the player.
      */
     var onVolumeRequest: (suspend (volume: Double) -> Unit)?
 }

--- a/common/src/main/java/dev/brahmkshatriya/echo/common/clients/MessagePostClient.kt
+++ b/common/src/main/java/dev/brahmkshatriya/echo/common/clients/MessagePostClient.kt
@@ -1,5 +1,6 @@
 package dev.brahmkshatriya.echo.common.clients
 
 interface MessagePostClient {
-    var postMessage: (String) -> Unit
+    fun postMessage(message: String)
+    fun setMessageHandler(handler: (String) -> Unit)
 }

--- a/common/src/main/java/dev/brahmkshatriya/echo/common/clients/MessagePostClient.kt
+++ b/common/src/main/java/dev/brahmkshatriya/echo/common/clients/MessagePostClient.kt
@@ -1,0 +1,5 @@
+package dev.brahmkshatriya.echo.common.clients
+
+abstract class MessagePostClient {
+    var postMessage: (String) -> Unit = {}
+}

--- a/common/src/main/java/dev/brahmkshatriya/echo/common/clients/MessagePostClient.kt
+++ b/common/src/main/java/dev/brahmkshatriya/echo/common/clients/MessagePostClient.kt
@@ -1,6 +1,17 @@
 package dev.brahmkshatriya.echo.common.clients
 
 interface MessagePostClient {
+    /**
+     * Posts a message to the user.
+     * Call this when you want to display a notification to the user.
+     *
+     * @param message The message text to display
+     */
     fun postMessage(message: String)
+
+    /**
+     * Internal setup method used by the main app.
+     * Extensions should not call this method.
+     */
     fun setMessageHandler(handler: (String) -> Unit)
 }

--- a/common/src/main/java/dev/brahmkshatriya/echo/common/clients/MessagePostClient.kt
+++ b/common/src/main/java/dev/brahmkshatriya/echo/common/clients/MessagePostClient.kt
@@ -1,5 +1,5 @@
 package dev.brahmkshatriya.echo.common.clients
 
-abstract class MessagePostClient {
-    var postMessage: (String) -> Unit = {}
+interface MessagePostClient {
+    var postMessage: (String) -> Unit
 }

--- a/common/src/main/java/dev/brahmkshatriya/echo/common/helpers/ExtensionType.kt
+++ b/common/src/main/java/dev/brahmkshatriya/echo/common/helpers/ExtensionType.kt
@@ -3,5 +3,6 @@ package dev.brahmkshatriya.echo.common.helpers
 enum class ExtensionType(val feature: String) {
     MUSIC("music"),
     TRACKER("tracker"),
-    LYRICS("lyrics")
+    LYRICS("lyrics"),
+    CONTROLLER("controller")
 }

--- a/common/src/main/java/dev/brahmkshatriya/echo/common/providers/ControllerClientsProvider.kt
+++ b/common/src/main/java/dev/brahmkshatriya/echo/common/providers/ControllerClientsProvider.kt
@@ -1,0 +1,8 @@
+package dev.brahmkshatriya.echo.common.providers
+
+import dev.brahmkshatriya.echo.common.ControllerExtension
+
+interface ControllerClientsProvider {
+    val requiredControllerClients: List<String>
+    fun setControllerExtensions(controllerClients: List<ControllerExtension>)
+}


### PR DESCRIPTION
# Fixes: 
 - Calling ``onExtensionSelected`` on disabled extensions other than music 
 - ``SettingTextInput`` not updating the shown value immediately after setting

# Additions
## MessagePostClient
- Allows an extension to hook into ``mutableMessageFlow`` to post messages other than errors
- Interface uses delegate/callback

## CloseableClient
- Allows extensions to close resources the app closes
- Tied to the player service which should be the last thing running in the app
- In my case this was useful for closing a websocket that otherwise kept running after the app was closed

## ControllerClient
- Allows an extension to perform actions directly onto the player
- Uses functions for app->extension communication and callbacks for extension->app communication
- Nicely documented

## examples:
### [Echo Song Skipper](https://github.com/rebelonion/echo-song-skipper)
- skips songs based off of song or artist name automatically

### [Echo Remote Control](https://github.com/rebelonion/echo-remote-control)
- connects to a control app through a websocket server to remotely control playback