### PR TITLE
Set channel count properly

### DIFF
--- a/app/src/main/java/dev/brahmkshatriya/echo/ui/player/quality/FormatUtils.kt
+++ b/app/src/main/java/dev/brahmkshatriya/echo/ui/player/quality/FormatUtils.kt
@@ -25,9 +25,12 @@ object FormatUtils {
     private fun Format.getHertz() =
         sampleRate.takeIf { it > 0 }?.let { " • $it Hz" } ?: ""
 
+    private fun Format.getChannelCount() =
+        channelCount.takeIf { it > 0 }?.let { " • ${it}ch" } ?: ""
+
     @OptIn(UnstableApi::class)
     fun Format.toAudioDetails() =
-        "${getMimeType()}${getHertz()} • ${channelCount}ch${getBitrate()}"
+        "${getMimeType()}${getHertz()}${getChannelCount()}${getBitrate()}"
 
     fun Format.toVideoDetails() = "${height}p${getFrameRate()}${getBitrate()}"
     fun Format.toSubtitleDetails() = label ?: language ?: "Unknown"


### PR DESCRIPTION
Some streams don't update `channelCount` so the quality text on the UI will be incontinent, will have something like `-1ch`. This PR makes sure to only set channel count when it's available.