### PR TITLE
Fix removing tracks from playlist

### DIFF
--- a/app/src/main/java/dev/brahmkshatriya/echo/extensions/builtin/unified/UnifiedDatabase.kt
+++ b/app/src/main/java/dev/brahmkshatriya/echo/extensions/builtin/unified/UnifiedDatabase.kt
@@ -167,11 +167,8 @@ abstract class UnifiedDatabase : RoomDatabase() {
             val track = dao.getTrack(tracks[it].toEntity().eid)!!
             dao.deletePlaylistTrack(track)
 
-            val before = dao.getTrack(track.after)
-            if (before != null) dao.insertPlaylistTrack(before.copy(after = track.after))
-
             val after = dao.getAfterTrack(track.eid)
-            if (after != null) dao.insertPlaylistTrack(track.copy(after = before?.eid))
+            if (after != null) dao.insertPlaylistTrack(after.copy(after = track.after))
 
             val entity = dao.getPlaylist(playlist.toEntity().id)
             if (entity.last == track.eid) dao.insertPlaylist(entity.copy(last = track.after))


### PR DESCRIPTION
This pr fixes removing tracks from playlist in unified extension, there's still race conditions when removing multiple tracks or getting tracks from playlist while still updating the playlist but nothing break the data stored in database. this pr just insures the data of playlist is intact when removing tracks.