### PR TITLE
(feat/offline-lyrics) Add Lyrics functionality to the Offline plugin

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -83,6 +83,9 @@ dependencies {
     implementation(libs.nestedscrollwebview)
     implementation(libs.acsbendi.webview)
 
+    implementation(libs.accompanist.core)
+    implementation(libs.jaudiotagger)
+
     if (!hasGoogleServices) return@dependencies
     implementation(libs.bundles.firebase)
 }

--- a/app/src/main/java/dev/brahmkshatriya/echo/extensions/builtin/offline/MediaStoreUtils.kt
+++ b/app/src/main/java/dev/brahmkshatriya/echo/extensions/builtin/offline/MediaStoreUtils.kt
@@ -290,6 +290,7 @@ object MediaStoreUtils {
         val durationColumn = cursor.getColumnIndexOrThrow(MediaStore.Audio.Media.DURATION)
         val addDateColumn = cursor.getColumnIndexOrThrow(MediaStore.Audio.Media.DATE_ADDED)
 
+
         while (cursor.moveToNext()) {
             val path = cursor.getStringOrNull(pathColumn) ?: continue
             val duration = cursor.getLongOrNull(durationColumn)
@@ -320,6 +321,7 @@ object MediaStoreUtils {
             val album = albumName?.let {
                 Album(albumId.toString(), it, null, null, albumArtist.toArtists())
             }
+
             val song = Track(
                 id = id.toString(),
                 title = title,
@@ -333,6 +335,7 @@ object MediaStoreUtils {
                     "genre" to (genre ?: context.getString(R.string.unknown)),
                     "addDate" to addDate.toString(),
                     "trackNumber" to trackNumber.toString(),
+                    "localFilePath" to path,
                     EXTENSION_ID to OfflineExtension.metadata.id
                 )
             )

--- a/app/src/main/java/dev/brahmkshatriya/echo/extensions/builtin/offline/TrackLyricsUtility.kt
+++ b/app/src/main/java/dev/brahmkshatriya/echo/extensions/builtin/offline/TrackLyricsUtility.kt
@@ -1,0 +1,31 @@
+package dev.brahmkshatriya.echo.extensions.builtin.offline
+
+import android.util.Log
+import org.jaudiotagger.audio.AudioFileIO
+import org.jaudiotagger.tag.FieldKey
+import java.io.File
+
+
+fun getLyricsFromAudioPath(audioPath: String): String? {
+    Log.i("[getLyricsFromAudioPath]", "getLyricsFromAudioPath entered with audio path $audioPath")
+    // first check for .lrc file
+    val lrcFile = File(audioPath).let {
+        File(it.parentFile, "${it.nameWithoutExtension}.lrc")
+    }
+    if (lrcFile.exists()) {
+        Log.i("[getLyricsFromAudioPath]", "Found LRC file, reading text and returning")
+        return lrcFile.readText(Charsets.UTF_8)
+    }
+
+    // fall back to embedded lyrics
+    return try {
+        Log.i("[getLyricsFromAudioPath]", "LRC file not found, loading file into memory and reading metadata")
+        val audioFile = AudioFileIO.read(File(audioPath))
+        Log.i("[getLyricsFromAudioPath]", "File read into memory, grabbing metadata")
+        audioFile.tag?.getFirst(FieldKey.LYRICS).also {
+            Log.i("[getLyricsFromAudioPath]", "Found lyrics in file, length = ${it?.length}")
+        }
+    } catch (e: Exception) {
+        null
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,6 +8,9 @@ koinAndroid = "4.1.0"
 media3 = "1.8.0"
 coil = "3.3.0"
 
+accompanist = "0.3.4"
+jaudiotagger = "2.2.5"
+
 [libraries]
 okhttp = { module = "com.squareup.okhttp3:okhttp", version = "5.1.0" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version = "1.9.0" }
@@ -65,6 +68,8 @@ acsbendi-webview = { module = "com.github.acsbendi:Android-Request-Inspector-Web
 firebase-analytics = { module = "com.google.firebase:firebase-analytics", version = "23.0.0" }
 firebase-crashlytics = { module = "com.google.firebase:firebase-crashlytics", version = "20.0.1" }
 
+accompanist-core = { module = "com.mocharealm.accompanist:lyrics-core", version.ref = "accompanist"}
+jaudiotagger = { module = "net.jthink:jaudiotagger", version.ref = "jaudiotagger" }
 [bundles]
 androidx = [
     "androidx-core-ktx", "androidx-appcompat", "androidx-activity", "fragment",


### PR DESCRIPTION
This feature has two methods of lyric discovery

1. check for a similarly named file with the `.lrc` file extension (using `java.io.File`)
2. check file metadata for a lyrics field (using `jaudiotagger`)

This works on my device (Pixel 9 Pro XL running latest GrapheneOS) but considering it might have permission issues it needs more testing.