### PR TITLE
Fix BT playback stall when switching tracks

### DIFF
--- a/app/src/main/java/dev/brahmkshatriya/echo/playback/PlayerService.kt
+++ b/app/src/main/java/dev/brahmkshatriya/echo/playback/PlayerService.kt
@@ -183,12 +183,6 @@ class PlayerService : MediaLibraryService() {
                     .build()
                 it.preloadConfiguration = ExoPlayer.PreloadConfiguration(C.TIME_UNSET)
                 it.skipSilenceEnabled = app.settings.getBoolean(SKIP_SILENCE, true)
-                it.addListener(object : Player.Listener {
-                    override fun onMediaItemTransition(mediaItem: MediaItem?, reason: Int) {
-                        it.pause()
-                        it.play()
-                    }
-                })
             }
     }
 


### PR DESCRIPTION
It happened with SBC and AAC codecs for 320kbps songs in deezer extension.
This fix works for me. Please can someone try to pair a BT device, select SBC or AAC codecs? Then if you have the same issue being fixed by this PR, please help me pushing this PR.

I'm quite new to dev, so please tell me if i'm doing something wrong.

Hope my work can help people :blush: