### PR TITLE
fix for spotify\yt bug

### DIFF
--- a/app/src/main/java/dev/brahmkshatriya/echo/playback/source/StreamableLoader.kt
+++ b/app/src/main/java/dev/brahmkshatriya/echo/playback/source/StreamableLoader.kt
@@ -22,6 +22,7 @@ import dev.brahmkshatriya.echo.playback.MediaItemUtils.serverIndex
 import dev.brahmkshatriya.echo.playback.MediaItemUtils.state
 import dev.brahmkshatriya.echo.playback.MediaItemUtils.subtitleIndex
 import dev.brahmkshatriya.echo.playback.MediaItemUtils.track
+import dev.brahmkshatriya.echo.R
 import dev.brahmkshatriya.echo.ui.media.MediaHeaderAdapter.Companion.playableString
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
@@ -83,7 +84,11 @@ class StreamableLoader(
             runCatching {
                 val isPlayable = mediaItem.track.playableString(app.context)
                 if (isPlayable != null) throw Exception(isPlayable)
-                val streamable = servers.getOrNull(index) ?: throw Exception("Server not found")
+                val streamable = when {
+                    index in servers.indices -> servers[index]
+                    servers.isNotEmpty() -> servers[0]
+                    else -> throw Exception(app.getString(R.string.no_streaming_sources))
+                }
                 loadStreamableMedia(
                     app, it, mediaItem.track, streamable
                 ).getOrThrow() as Streamable.Media.Server

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -68,6 +68,7 @@
 
     <string name="extension_out_of_date">Out of date</string>
     <string name="no_internet">No Internet</string>
+    <string name="no_streaming_sources">No streaming sources available. Check your network connection or try logging in again.</string>
     <string name="error_loading_extension_from_x">Error loading extension from %1$s</string>
     <string name="extension_x_not_found">Extension %1$s not found</string>
     <string name="required_extensions_missing_x">Required extensions missing: %1$s</string>


### PR DESCRIPTION
Cause of "Server not found"
The error was thrown in StreamableLoader.kt when:
No streaming servers – The track’s servers list was empty (e.g. extension couldn’t get stream URLs due to network/API/login).
Invalid server index – serverIndex was out of range (e.g. -1 or a value from an old/restored queue).
Offline still worked because that path uses downloaded files and doesn’t look up a server by index.
Changes made
StreamableLoader.kt

So:
Index problems (wrong/stale serverIndex) are handled by falling back to the first server, which should fix many "Server not found" cases for Spotify/YouTube when the track actually has servers.
Real “no servers” cases (e.g. network/API/login) now show a clear message instead of the generic "Server not found".
If you still see the new “No streaming sources available…” message, then the extension really isn’t getting any stream URLs; 