### PR TITLE
Add artists with ampersand exclusion list and mojibake fix

### DIFF
--- a/app/src/main/java/dev/brahmkshatriya/echo/extensions/builtin/offline/MediaStoreUtils.kt
+++ b/app/src/main/java/dev/brahmkshatriya/echo/extensions/builtin/offline/MediaStoreUtils.kt
@@ -35,6 +35,10 @@ object MediaStoreUtils {
 
     private const val TAG = "MediaStoreUtils"
 
+    // settings key used by OfflineExtension; contains comma-separated names that should not
+    // be treated as separate artists even if they contain commas or ampersands.
+    private const val ARTIST_EXCLUSIONS = "artist_exclusions"
+
     interface Item {
         val id: Long?
         val title: String?
@@ -273,6 +277,7 @@ object MediaStoreUtils {
         songs: MutableList<Track>,
         foundPlaylistContent: Boolean,
         idMap: MutableMap<Long, Track>?,
+        settings: Settings,
         block: (Track) -> Unit,
     ) = use { cursor ->
         // Get columns from mediaStore.
@@ -290,6 +295,13 @@ object MediaStoreUtils {
         val durationColumn = cursor.getColumnIndexOrThrow(MediaStore.Audio.Media.DURATION)
         val addDateColumn = cursor.getColumnIndexOrThrow(MediaStore.Audio.Media.DATE_ADDED)
 
+        // prepare exclusions for this cursor scan (pipe-separated)
+        val artistExclusions = settings.getString(ARTIST_EXCLUSIONS)
+            ?.split('|')
+            ?.mapNotNull { it.trim().takeIf { s -> s.isNotBlank() } }
+            ?.toSet()
+            ?: emptySet()
+
         while (cursor.moveToNext()) {
             val path = cursor.getStringOrNull(pathColumn) ?: continue
             val duration = cursor.getLongOrNull(durationColumn)
@@ -300,11 +312,18 @@ object MediaStoreUtils {
             // We need to add blacklisted songs to idMap as they can be referenced by playlist
             if (skip && !foundPlaylistContent) continue
             val id = cursor.getLongOrNull(idColumn)!!
-            val title = cursor.getStringOrNull(titleColumn)!!
-            val artist = cursor.getStringOrNull(artistColumn)
-                .let { v -> if (v == "<unknown>") null else v }
-            val albumName = cursor.getStringOrNull(albumColumn)
-            val albumArtist = cursor.getStringOrNull(albumArtistColumn)
+            // read metadata strings and normalise any mojibake from Windows-1252 encoded
+        // smart punctuation.  Android sometimes returns garbage like "â€™" when the
+        // original tag was U+2019 but decoded incorrectly; fix the common cases here.
+        // the title must be non-null for Track, so default to empty if missing.
+        val title = cursor.getStringOrNull(titleColumn)
+            .fixWin1252()
+            ?: ""
+        val artist = cursor.getStringOrNull(artistColumn)
+            .fixWin1252()
+            .let { v -> if (v == "<unknown>") null else v }
+        val albumName = cursor.getStringOrNull(albumColumn).fixWin1252()
+        val albumArtist = cursor.getStringOrNull(albumArtistColumn).fixWin1252()
             val trackNumber = cursor.getIntOrNull(trackNumberColumn)
             val year = cursor.getIntOrNull(yearColumn).let { v -> if (v == 0) null else v }
             val albumId = cursor.getLongOrNull(albumIdColumn)
@@ -316,9 +335,9 @@ object MediaStoreUtils {
                 context.contentResolver.runCatching { openInputStream(uri)!!.close() }.isSuccess
             }
 
-            val artists = artist.toArtists()
+            val artists = artist.toArtists(artistExclusions)
             val album = albumName?.let {
-                Album(albumId.toString(), it, null, null, albumArtist.toArtists())
+                Album(albumId.toString(), it, null, null, albumArtist.toArtists(artistExclusions))
             }
             val song = Track(
                 id = id.toString(),
@@ -437,6 +456,12 @@ object MediaStoreUtils {
         val folderFilter = settings.getStringSet("blacklist_folders") ?: setOf()
         val blacklistKeywords = settings.getString("blacklist_keywords")?.split(',')
             ?.mapNotNull { it.trim().takeIf { s -> s.isNotBlank() } }.orEmpty()
+        // parse the user-defined exclusion list; stored as pipe-separated values in settings.
+        val artistExclusions = settings.getString(ARTIST_EXCLUSIONS)
+            ?.split('|')
+            ?.mapNotNull { it.trim().takeIf { s -> s.isNotBlank() } }
+            ?.toSet()
+            ?: emptySet()
         // Initialize list and maps.
         val coverCache = if (haveImgPerm) hashMapOf<Long, Pair<File, FileNode>>() else null
         val folders = hashSetOf<String>()
@@ -470,6 +495,7 @@ object MediaStoreUtils {
             songs,
             foundPlaylistContent,
             idMap,
+            settings,              // pass settings so helper can access exclusions
         ) { song ->
             song.artists.map {
                 val id = it.id.toLongOrNull()
@@ -683,13 +709,35 @@ object MediaStoreUtils {
         return d[m][n]
     }
 
-    private fun String?.splitArtists() = this?.split(",", "&", " and ")
-        ?.mapNotNull { it.trim().takeIf { s -> s.isNotBlank() } }
-        ?: listOf(null)
+    private fun String?.splitArtists(exclusions: Set<String> = emptySet()) =
+        if (this != null && exclusions.contains(this.trim()))
+            listOf(this.trim())
+        else this?.split(",", "&", " and ")
+            ?.mapNotNull { it.trim().takeIf { s -> s.isNotBlank() } }
+            ?: listOf(null)
 
-    private fun String?.toArtists() = takeIf { this != "null" }.splitArtists().map {
-        Artist(it?.id().toString(), it ?: "Unknown")
+    /**
+     * Workaround for tags that contain Windows-1252 smart punctuation which was
+     * mis‑decoded by the media provider.  Converts common mojibake sequences back
+     * to their intended characters.
+     */
+    private fun String?.fixWin1252(): String? = this?.let { s ->
+        s.replace("â€™", "’")
+            .replace("â€“", "–")
+            .replace("â€”", "—")
+            .replace("â€œ", "“")
+            .replace("â€�", "”")
+            .replace("â€˜", "‘")
+            .replace("â€¦", "…")
+            // any additional mappings can be added here
     }
+
+    private fun String?.toArtists(exclusions: Set<String> = emptySet()) =
+        takeIf { this != "null" }
+            .splitArtists(exclusions)
+            .map {
+                Artist(it?.id().toString(), it ?: "Unknown")
+            }
 
     fun String.id() = this.lowercase().hashCode().toLong()
 }

--- a/app/src/main/java/dev/brahmkshatriya/echo/extensions/builtin/offline/OfflineExtension.kt
+++ b/app/src/main/java/dev/brahmkshatriya/echo/extensions/builtin/offline/OfflineExtension.kt
@@ -114,6 +114,14 @@ class OfflineExtension(
                 context.getString(R.string.blacklist_folder_keywords),
                 "blacklist_keywords",
                 context.getString(R.string.blacklist_folder_keywords_summary)
+            ),
+            // user can supply a pipe‑separated list of artist names that should not be
+            // split even if they contain commas or ampersands (or pipes).  Example:
+            // "Paola & Chiara | Earth, Wind & Fire".
+            SettingTextInput(
+                context.getString(R.string.artist_exclusions),
+                "artist_exclusions",
+                context.getString(R.string.artist_exclusions_summary)
             )
         )
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -31,6 +31,8 @@
     <string name="blacklist_folders_summary">Folders to exclude from the library</string>
     <string name="blacklist_folder_keywords">Blacklist Folder Keywords</string>
     <string name="blacklist_folder_keywords_summary">Keywords to blacklist folders, use comma for separator</string>
+    <string name="artist_exclusions">Artist exclusions</string>
+    <string name="artist_exclusions_summary">Pipe-separated list of artist names that should not be split (use “|”)</string>
     <string name="saved">Saved</string>
     <string name="tabs">Tabs</string>
     <string name="show_tabs">Show Tabs</string>


### PR DESCRIPTION
Hi. I'm bringing two fixes that are making my experience with Echo better. Both fixes are kind of related with the Last.fm scrobbling ability, but what I first fixed as a workaround in the Last.fm extension has now become a fix that goes to the root problem in the offline extension.

1) Artist splitting: the media store parser treated ,, & and and as separators, which meant duos like “Paola & Chiara” were stored as two artists. I’ve added a new “Artist exclusions” preference (pipe‑separated list) and modified the parsing helpers so any name on that list is kept whole. The setting is exposed through the offline extension’s settings screen and the library automatically refreshes whenever it’s changed. 

2) Mojibake of smart punctuation: many tags are encoded in Windows‑1252; when the media provider delivers those strings as UTF‑8 they turn into â€™, â€“ etc. I added a small normalisation helper that corrects the common mapping sequences right after the cursor reads the fields, so apostrophes, dashes and quotes now display properly.

AI statement: I used GitHub Copilot to easily find the code sections that should be modified for this purpose.

I have reviewed all the code manually, built the app and test it with no errors found so far.