### PR TITLE
fix: prevent script injection in handle-extension-issues workflow

### DIFF
--- a/.github/workflows/handle-extension-issues.yml
+++ b/.github/workflows/handle-extension-issues.yml
@@ -11,8 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Debug Issue Body
+        env:
+          ISSUE_BODY: ${{ github.event.issue.body }}
         run: |
-          echo "Issue body: ${{ github.event.issue.body }}"
+          echo "Issue body: $ISSUE_BODY"
       - name: Check for Extension Checkbox
         uses: actions/github-script@v6
         with:


### PR DESCRIPTION
## Summary

- Fix script injection vulnerability in `.github/workflows/handle-extension-issues.yml`
- Move `github.event.issue.body` from inline `${{ }}` interpolation to an environment variable to prevent shell injection

## Reference

- [GitHub Docs: Security hardening - Script injections](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#understanding-the-risk-of-script-injections)